### PR TITLE
fix(index.d.ts): 잘못된 export 수정

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,5 +75,7 @@ declare module '@actbase/react-native-kakao-login' {
     unlink: () => Promise<'SUCCESS'>;
   }
 
-  export default ARNKakaoLogin;
+  const KakaoLogin: ARNKakaoLogin;
+
+  export default KakaoLogin;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/964412/113473799-cbd2bd80-94a6-11eb-9232-6d793de19dd3.png)

- 현재 타입 정의 파일(index.d.ts)에서는 index.js에 정의된 상수 `KakaoLogin` 대신 `ARNKakaoLogin`이라는 interface를 반환하고 있습니다.
- 값 대신 타입을 반환하고 있기 때문에 타입스크립트 사용 시 TS2693 오류가 발생하게 되므로 이를 수정합니다.
